### PR TITLE
Monotonic timestamp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export class BaselimeLogger {
 	private flushAfterLogs: number;
 	private baselimeUrl: string;
 	private isLocalDev: boolean;
+	private monotonicTimestamp: number;
 
 	constructor(args: BaselimeLoggerArgs) {
 		this.ctx = args.ctx;
@@ -53,6 +54,7 @@ export class BaselimeLogger {
 			this.requestId = crypto.randomUUID();
 		}
 		this.isLocalDev = args.isLocalDev;
+		this.monotonicTimestamp = Date.now();
 	}
 
 	private async _log(
@@ -82,11 +84,19 @@ export class BaselimeLogger {
 			return;
 		}
 
+		let timestamp = Date.now();
+		if (timestamp > this.monotonicTimestamp) {
+			this.monotonicTimestamp = timestamp;
+		} else {
+			timestamp = this.monotonicTimestamp;
+			this.monotonicTimestamp += 1;
+		}
+
 		const log: BaselimeLog = {
 			message,
 			level: (data?.level as string) || level,
 			traceId,
-			timestamp: Date.now(),
+			timestamp,
 			requestId: this.requestId,
 			...data,
 		};


### PR DESCRIPTION
Closes #10

Screenshot shows top set of logs using monotonic timestamp and bottom set using `Date.now()`.

<img width="518" alt="Screenshot 2024-05-14 at 11 32 19 AM" src="https://github.com/baselime/edge-logger/assets/425584/5b9b49bd-5f82-4426-a645-afda399dc482">
