### PR TITLE
Fix monotonic timestamp after Date.now() advances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ class MonotonicTimestamp {
 	now() {
 		let timestamp = Date.now();
 		if (timestamp > this.monotonicTimestamp) {
-			this.monotonicTimestamp = timestamp;
+			this.monotonicTimestamp = timestamp + 1;
 		} else {
 			timestamp = this.monotonicTimestamp;
 			this.monotonicTimestamp += 1;


### PR DESCRIPTION
Closes #12 

The second set of logs in the screenshot below show a repeating timestamp for the last two logs. The first set of logs shows the correct behavior with no repeating timestamps.

<img width="545" alt="Screenshot 2024-05-15 at 7 59 44 PM" src="https://github.com/baselime/edge-logger/assets/425584/f639baaf-5675-4296-8b6e-bf6a65ac0b52">
